### PR TITLE
add modules that open up way to the top before excluding deps of excluded deps + test case

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -945,12 +945,15 @@ class EasyBlock(object):
         excluded_deps = self.modules_tool.path_to_top_of_module_tree(top_paths, self.cfg.short_mod_name,
                                                                      full_mod_subdir, deps)
         self.log.debug("List of excluded deps: %s", excluded_deps)
+        print 'excluded_deps', excluded_deps
 
         deps = [d for d in deps if d not in excluded_deps]
         for dep in excluded_deps:
             excluded_dep_deps = dependencies_for(dep, self.modules_tool)
+            print 'dep', dep, 'excluded_dep_deps', excluded_dep_deps
             self.log.debug("List of dependencies for excluded dependency %s: %s" % (dep, excluded_dep_deps))
             deps = [d for d in deps if d not in excluded_dep_deps]
+
         self.log.debug("List of retained deps to load in generated module: %s" % deps)
         recursive_unload = self.cfg['recursive_module_unload']
 

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -945,12 +945,13 @@ class EasyBlock(object):
         excluded_deps = self.modules_tool.path_to_top_of_module_tree(top_paths, self.cfg.short_mod_name,
                                                                      full_mod_subdir, deps)
         self.log.debug("List of excluded deps: %s", excluded_deps)
-        print 'excluded_deps', excluded_deps
+
+        # load modules that open up the module tree before checking deps of deps (in reverse order)
+        self.modules_tool.load(excluded_deps[::-1])
 
         deps = [d for d in deps if d not in excluded_deps]
         for dep in excluded_deps:
             excluded_dep_deps = dependencies_for(dep, self.modules_tool)
-            print 'dep', dep, 'excluded_dep_deps', excluded_dep_deps
             self.log.debug("List of dependencies for excluded dependency %s: %s" % (dep, excluded_dep_deps))
             deps = [d for d in deps if d not in excluded_dep_deps]
 

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -421,6 +421,43 @@ class EasyBlockTest(EnhancedTestCase):
         expected = tc_load + '\n\n' + fftw_load + '\n\n' + lapack_load
         self.assertEqual(eb.make_module_dep(unload_info=unload_info).strip(), expected)
 
+    def test_make_module_dep_hmns(self):
+        """Test for make_module_dep under HMNS"""
+        test_ecs_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
+        all_stops = [x[0] for x in EasyBlock.get_steps()]
+        build_options = {
+            'check_osdeps': False,
+            'robot_path': [test_ecs_path],
+            'valid_stops': all_stops,
+            'validate': False,
+        }
+        os.environ['EASYBUILD_MODULE_NAMING_SCHEME'] = 'HierarchicalMNS'
+        init_config(build_options=build_options)
+        self.setup_hierarchical_modules()
+
+        print self.modtool.available()
+
+        self.contents = '\n'.join([
+            'easyblock = "ConfigureMake"',
+            'name = "pi"',
+            'version = "3.14"',
+            'homepage = "http://example.com"',
+            'description = "test easyconfig"',
+            "toolchain = {'name': 'goolf', 'version': '1.4.10'}",
+            'dependencies = [',
+            #"   ('GCC', '4.7.2', '', True),",
+            #"   ('OpenMPI', '1.6.4', '', ('GCC', '4.7.2')),",
+            "   ('FFTW', '3.3.3', '', ('gompi', '1.4.10')),",
+            ']',
+        ])
+        self.writeEC()
+        eb = EasyBlock(EasyConfig(self.eb_file))
+
+        eb.installdir = os.path.join(config.install_path(), 'pi', '3.14')
+        eb.check_readiness_step()
+
+        print eb.make_module_dep()
+
     def test_extensions_step(self):
         """Test the extensions_step"""
         self.contents = '\n'.join([

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -435,8 +435,6 @@ class EasyBlockTest(EnhancedTestCase):
         init_config(build_options=build_options)
         self.setup_hierarchical_modules()
 
-        print self.modtool.available()
-
         self.contents = '\n'.join([
             'easyblock = "ConfigureMake"',
             'name = "pi"',
@@ -445,9 +443,9 @@ class EasyBlockTest(EnhancedTestCase):
             'description = "test easyconfig"',
             "toolchain = {'name': 'goolf', 'version': '1.4.10'}",
             'dependencies = [',
-            #"   ('GCC', '4.7.2', '', True),",
-            #"   ('OpenMPI', '1.6.4', '', ('GCC', '4.7.2')),",
-            "   ('FFTW', '3.3.3', '', ('gompi', '1.4.10')),",
+            "   ('GCC', '4.7.2', '', True),"
+            "   ('hwloc', '1.6.2', '', ('GCC', '4.7.2')),",
+            "   ('OpenMPI', '1.6.4', '', ('GCC', '4.7.2')),"
             ']',
         ])
         self.writeEC()
@@ -456,7 +454,11 @@ class EasyBlockTest(EnhancedTestCase):
         eb.installdir = os.path.join(config.install_path(), 'pi', '3.14')
         eb.check_readiness_step()
 
-        print eb.make_module_dep()
+        # GCC, OpenMPI and hwloc modules should *not* be included in loads for dependencies
+        mod_dep_txt = eb.make_module_dep()
+        for mod in ['GCC/4.7.2', 'OpenMPI/1.6.4', 'hwloc/1.6.2']:
+            regex = re.compile('load.*%s' % mod)
+            self.assertFalse(regex.search(mod_dep_txt), "Pattern '%s' found in: %s" % (regex.pattern, mod_dep_txt))
 
     def test_extensions_step(self):
         """Test the extensions_step"""


### PR DESCRIPTION
for https://github.com/hpcugent/easybuild-framework/pull/2091

@bartoldeman please review the changes being made here; if you merge this PR, your PR @ https://github.com/hpcugent/easybuild-framework/pull/2091 will be updated to include these changes

The test case is a bit strange, but it basically covers what needs to be tested.

Without your patch the `load` for `hwloc` is still there, now it's not anymore.