### PR TITLE
enhance test_toy_modaltsoftname

### DIFF
--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1265,6 +1265,8 @@ class ToyBuildTest(EnhancedTestCase):
         toy_ec_file = os.path.join(topdir, 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0.eb')
         toy_ec_txt = read_file(toy_ec_file)
 
+        self.assertFalse(re.search('^modaltsoftname', toy_ec_txt, re.M))
+
         ec1 = os.path.join(self.test_prefix, 'toy-0.0-one.eb')
         ec1_txt = '\n'.join([
             toy_ec_txt,
@@ -1281,9 +1283,11 @@ class ToyBuildTest(EnhancedTestCase):
         ])
         write_file(ec2, ec2_txt)
 
-        self.test_toy_build(ec_file=self.test_prefix, verify=False,
-                            extra_args=['--module-naming-scheme=HierarchicalMNS', 
-                                        '--robot-paths=%s'%self.test_prefix])
+        extra_args = [
+            '--module-naming-scheme=HierarchicalMNS',
+            '--robot-paths=%s'%self.test_prefix,
+        ]
+        self.test_toy_build(ec_file=self.test_prefix, verify=False, extra_args=extra_args, raise_error=True)
 
 
 def suite():


### PR DESCRIPTION
@bartoldeman two minor enhancements to the test you added in https://github.com/hpcugent/easybuild-framework/pull/2138 (+ some style cleanup):

* make very sure that `modaltsoftname` is not used by the toy easyconfig (we may add it in the future without realising it would affect this test)

* enable `raise_error` in the call to `test_toy_build` to ensure that the test actually *fails* without the fix implemented in 2ceea04 (see the commit status of 8b81200 that is green, while the test should fail without the fix added in 2ceea04)